### PR TITLE
chore: pin GitHub Actions to commit hash and upgrade versions

### DIFF
--- a/.github/actions/setup-node-version/action.yml
+++ b/.github/actions/setup-node-version/action.yml
@@ -2,7 +2,7 @@ runs:
   using: composite
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: ./.node-version
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/setup-node-version
@@ -31,7 +31,7 @@ jobs:
   spell-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/setup-node-version
@@ -42,7 +42,7 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/setup-node-version
@@ -53,7 +53,7 @@ jobs:
   test-jest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: setup
         uses: ./.github/actions/setup-node-version


### PR DESCRIPTION
## Summary
- actions/checkout を v4 から v7.0.1 (`3d3c42e5aac5ba805825da76410c181273ba90b1`) にアップグレードし、コミットハッシュで固定
- actions/setup-node を v4 から v7.0.0 (`820762786026740c76f36085b0efc47a31fe5020`) にアップグレードし、コミットハッシュで固定

## Test plan
- [ ] CI (lint / spell-check / type-check / test-jest) がグリーンであることを確認