### PR TITLE
add sync-strict-check skill and sync package documents

### DIFF
--- a/.claude/skills/sync-strict-check/SKILL.md
+++ b/.claude/skills/sync-strict-check/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: sync-strict-check
+description: 本家 strict-check(eslint-config-sc-* / eslint-plugin-sc-js)のリリース内容を、このドキュメントサイトへ一方向に同期するためのスキル。パッケージごとの最新リリースタグを正とし、同期マトリクスに沿って差分を検知・提示し、承認後に実装・検証まで行う。`/sync-strict-check` で明示的に起動する他、本家のリリース内容をドキュメントへ反映する作業を検知した際にも使う。
+model: opus
+---
+
+# sync-strict-check
+
+このスキルは、本家 [strict-check](https://github.com/akky-xxxx/strict-check) の公開内容を、このドキュメントサイトへ反映するための手順書です。同期は **strict-check(正)→ 本リポジトリ(従)の一方向** であり、逆方向の書き換えは行いません。
+
+ドキュメントは npm に publish 済みの内容を掲載すべきなので、**パッケージごとの最新リリースタグ** を正とします(未リリースの `develop` の変更を先行掲載しない)。
+
+差分の実装は `.claude/rules/implementation-rules.md` により着手前の承認が必須のため、手順3の確認ステップを飛ばしてはいけません。
+
+## 手順
+
+### 参照元の解決
+
+1. **ローカルクローンの確認**: `STRICT_CHECK_DIR=/Users/shogo_akimoto/src/01.private/strict-check` の存在を確認する。存在しない場合のみ `gh api repos/akky-xxxx/strict-check/contents/<path>?ref=<tag>` にフォールバックする(複数ファイルの取得が遅いため、ローカルクローンを優先する)
+2. **タグの取得**: `git -C "$STRICT_CHECK_DIR" fetch --tags --prune`
+3. **パッケージごとの最新リリースタグを解決**: タグは `<npm パッケージ名>/v<version>` 形式(例: `eslint-config-sc-js/v0.2.2`、`eslint-plugin-sc-js/v0.3.0`)。パッケージごとにバージョンが異なりうるため個別に解決する
+
+   ```bash
+   git -C "$STRICT_CHECK_DIR" tag --list "<npm パッケージ名>/v*" --sort=-v:refname | head -1
+   ```
+
+4. **ディレクトリ名と npm 名の対応**: 両者は一致しない(`packages/eslint-config-js` → `eslint-config-sc-js`、`packages/eslint-plugin-js` → `eslint-plugin-sc-js`)。対応は必ずタグ時点の `packages/*/package.json` の `name` から導出し、ハードコードしない
+
+   ```bash
+   for dir in $(git -C "$STRICT_CHECK_DIR" ls-tree -d --name-only "$tag" packages/); do
+     git -C "$STRICT_CHECK_DIR" show "$tag:$dir/package.json"
+   done
+   ```
+
+5. **ファイルの読み取り**: `git -C "$STRICT_CHECK_DIR" show <tag>:<path>` で読む。作業ツリーやチェックアウト中のブランチを直接読まない
+6. **ref の明示指定**: 起動時に引数で ref を渡された場合(例: `/sync-strict-check develop`)はそれを全パッケージ共通の参照先として優先し、「未リリース内容を参照している」旨をレポートに明記する
+
+### 差分の抽出(同期マトリクス)
+
+以下の観点ごとに、strict-check 側の正本と本リポジトリ側の反映先を突き合わせる。
+
+| 観点 | strict-check 側の正本 | 本リポジトリ側の反映先 |
+|---|---|---|
+| パッケージ一覧の増減 | `packages/*/package.json` の `name` | `src/app/packages/<name>/page.tsx`、`src/components/templates/EslintConfigSC*/`、`src/components/templates/Packages/constants/ESLINT_CONFIG_ITEMS`・`ESLINT_PLUGIN_ITEMS`、`src/shared/constants/HEADINGS_INFO`、`src/components/atoms/*Introduction/` |
+| config の公開 API(`configs` のキー) | `packages/eslint-config-*/src/index.ts` | `src/components/templates/EslintConfigSC*/components/atoms/Setup/constants/CODES`(`FLAT1`〜`FLAT3`) |
+| recommended の合成順 | `packages/eslint-config-*/src/flatConfig/index.ts` の配列順 | 同上 CODES の記載順 |
+| `eslint-config-sc-all` の関数シグネチャ | `packages/eslint-config-all/src/getConfigs/index.ts` の `GetConfigs` 型、`src/shared/types/Library/index.ts` | `src/components/templates/EslintConfigSCAll/components/atoms/Setup`・`Arguments` |
+| plugin ルールの増減と recommended 収録 | `packages/eslint-plugin-js/src/ruleBase/index.ts`(severity が `OFF` 以外 = 一覧表の ✅) | `src/components/atoms/EslintPluginJsRules/constants/ITEMS`、`src/app/packages/eslint-plugin-sc-js/rules/<rule>/page.tsx`、`src/components/templates/EslintPluginSCJsRules<Rule>/` |
+| ルールのオプション仕様 | `packages/eslint-plugin-js/src/rules/<rule>/schema/optionSchema/index.ts`(zod)と `types/` | `src/components/templates/EslintPluginSCJsRules<Rule>/constants/CODES` の `OPTIONS`、および各オプションの Heading3 セクション |
+| ルールの検知内容 | `packages/eslint-plugin-js/src/rules/<rule>/index.ts` の `meta.messages` / `meta.type` と `modules/` の判定ロジック | 各ルールページの説明文、`INCORRECT_EXAMPLE` / `CORRECT_EXAMPLE` |
+| peerDependencies | `packages/*/package.json` の `peerDependencies` | 各 `Installation`(追加インストールの案内が必要か) |
+| shared config の由来説明("This package sets some rules based on the shared config of below packages." 等) | `packages/eslint-config-*/src/shared/config/records/**/*.ts`(**全ファイル**。`modules/`・`settings/` 配下のサブモジュールも含む) | `src/components/atoms/*Introduction/`(`index.tsx` の文言と `constants/LINK_ITEMS`) |
+| plugin の登録キーとルール名の prefix | `modules/shared-for-eslint-plugin/src/constants/SUFFIX`(`"sc-"`)+ `packages/eslint-plugin-js/src/index.ts` の `PLUGIN_NAME`(`"js"`)。`getFlatConfig` が `plugins` のキーを、`getConfigRules` がルール名を、いずれも `` `${SUFFIX}${PLUGIN_NAME}` `` として組み立てる | `src/components/templates/EslintPluginSCJs/components/atoms/Setup`・`src/components/templates/EslintPluginSCJsRules/components/atoms/Setup` の `plugins` キー、および各ルールページ `constants/CODES` の `OPTIONS` のルール名 |
+
+観点ごとの補足:
+
+- **ルールの description 文言**: strict-check 側のルールは `meta.docs` を持たないため、一覧表(`EslintPluginJsRules/constants/ITEMS`)の説明文はこのドキュメントサイトが唯一の正本。**ここは strict-check 側の内容で上書きしない**(ルールが新規追加されたときのみ新規に書き起こす)
+- **peerDependencies**: 現状 `Installation` はパッケージ本体のインストールのみを案内しており、peer の明示は意図的に省略されている可能性がある。差分があっても自動的に書き換えず、レポートで記載要否をユーザーに確認する
+  - **`package.json` の `peerDependencies` だけでは正確な実態を捉えられない**。過大申告(例: `eslint-config-sc-js` は `@eslint/eslintrc` を peer に挙げているが、実装内では型宣言 `declare module "@eslint/eslintrc"` に使われているだけで実行時には一切参照されない)と過小申告(例: `eslint-config-sc-react` の `reactRecords` は `getCompatExtends("plugin:react/recommended", ...)` 経由で実行時に `eslint-plugin-react` を要求するが、`package.json` の `peerDependencies` には載っていない)の両方が起こりうる。**必ず各 record ファイルの実装(`require(...)` / `import ... from "..."` / `getCompatExtends(...)` の引数)を読んで実際の依存を確認し、宣言だけを鵜呑みにしない**
+  - `eslint-config-sc-all` は特に注意: `getConfigs(language, libraries)` の `language` 引数により `eslint-config-sc-js` と `eslint-config-sc-ts` は**どちらか一方のみ**が使われる(`src/getConfigs/modules/getConfigsBase/modules/getConfigsBaseForJavascript` / `getConfigsBaseForTypescript` を参照)。`package.json` の `peerDependenciesMeta` はこの2つを optional 扱いにしておらず(4つの library 系 peer のみ optional)、鵜呑みにすると両方を無条件必須として案内してしまう誤りを犯す(実際に一度そう実装してしまった実例あり)
+- **plugin の登録キー**: `PLUGIN_NAME` を単体で見て `"js"` と早合点しない。`SUFFIX`(`"sc-"`)との連結が実際のキーであり、正解は `"sc-js"`。`getFlatConfig` のテスト(`modules/shared-for-eslint-plugin/spec/utilities/getFlatConfig/index.test.ts`)が `getFlatConfig("test", {}, [])` → `plugins: { "sc-test": {} }` と明示的に assert しているので、迷ったらこのテストを見る。手動登録のサンプル(recommended を使わない場合)でキーを間違えると、各ルールページが案内する `sc-js/<rule>` というルール名が解決できず「Definition for rule not found」になる(実際に `"js"` と誤記されていた実例あり)
+- **CODES の網羅検証**: 目視のスポットチェックで済ませず、CODES から `configs.<key>` の参照を機械的に全件抽出し、各パッケージの `src/index.ts` の実在キーと総当たりで突き合わせる。存在しないキーの記載(過去に `stylisticRecord` / `resetRecordForStylistic` / `typescriptEslintStylisticTypeCheckedRecords` の実例あり)と、実在するのに記載漏れのキー(`importRecommendedRecord` の実例あり)の両方を検出できる
+
+  ```bash
+  grep -rhoE "eslintConfigSC[A-Za-z]+\.configs\.[A-Za-z]+" \
+    src/components/templates/EslintConfigSC*/components/atoms/Setup/constants/CODES/index.ts | sort -u
+  ```
+
+- **shared config の由来説明**: `src/index.ts` の `configs` キー一覧だけでなく、**各 record ファイルの中身を1つずつ読んで**、(a) 実在の npm パッケージの `recommended`/`flatConfigs` 等を丸ごと spread しているもの(例: `unicornRecommendedRecords` → `eslint-plugin-unicorn`)、(b) 他の `eslint-config-sc-*` パッケージの `configs` に委譲しているだけのもの(例: `eslint-config-sc-ts` の大半は `eslintConfigSCJs.configs.*` を re-export)、(c) 特定パッケージのルールを手動で移植した自前実装(例: `airbnbBaseReplacement.ts` は `eslint-config-airbnb-base` のルールを個別にコピーしただけで、そのパッケージ自体には依存していない)を判別する。Introduction の「shared config of below packages」に列挙してよいのは (a)(b) のみで、(c) を実在パッケージへの依存であるかのように書かない(除外する)
+
+### 差分レポートの提示(承認必須)
+
+観点ごとに「対象パッケージ / 参照タグ / strict-check 側の現在値 / 本リポジトリ側の現在値 / 差分 / 対応方針」を提示し、着手前に承認を得る。差分が無い場合はその旨を報告して終了する。
+
+### 実装
+
+- 既存ページの文言・サンプルコードの修正で済む場合は、承認された対応方針に沿ってこのスキル内で実装する
+- **ページの新規追加(パッケージ追加・ルール追加)を伴う場合は `/feature-flow` に委譲する**。委譲時は以下の変更対象を引き継ぐ
+  - `src/app/packages/.../page.tsx`(薄いラッパー。`src/components/templates` を描画するだけ)
+  - `src/components/templates/<Name>/`(`index.tsx` と `index.stories.tsx`。既存の同種テンプレートを参考にする)
+  - 一覧の constants: `templates/Packages/constants/ESLINT_CONFIG_ITEMS`・`ESLINT_PLUGIN_ITEMS`、`atoms/EslintPluginJsRules/constants/ITEMS`
+  - `src/shared/constants/HEADINGS_INFO`(`searchTitle` はサイト内検索が参照するため必ず埋める)
+  - `src/components/atoms/*Introduction/`(パッケージ追加時)
+  - `pnpm build:pathpida` で `@lib/$path` を再生成してから `pagesPath` を参照する
+
+### 検証
+
+`pnpm check-code`(lint 一式・spell-check・type-check・test-jest)を実行する。ページを新規追加した場合は pathpida の生成物が絡むため `pnpm build` も実行する。
+
+### 完了報告
+
+同期した観点・参照タグ・後述の「報告のみに留めた事項」をユーザーに報告して、このスキルの担当範囲は終わり。コミット以降は `.claude/rules/commit-rules.md` に従う。
+
+## 注意点
+
+- 同期は一方向。このスキルから strict-check 側のファイルを書き換えない。逆方向の要修正点(例: strict-check の `packages/*/package.json` の `homepage` と各 README が旧 Cloudflare URL `strict-check-series.pages.dev` を指したままで、Vercel 移行後の URL と乖離している)を見つけた場合は**報告のみ**に留める
+- 参照は必ずタグ経由の `git show` で行う。ローカルの作業ツリーやチェックアウト中のブランチの内容を正としない(strict-check 側は通常 `develop` がチェックアウトされており、未リリースの変更を含む)
+- パッケージのバージョンはパッケージごとに異なりうる。全パッケージを同一バージョンとみなさない
+- 一覧表の ✅ は「recommended 構成に含まれるか」を意味する。`ruleBase` の severity が `OFF` 以外であることが条件で、`WARN` でも ✅ が付く
+- `src/lib/$path.ts`(pathpida)と `styled-system/`(Panda CSS)は生成物のため直接編集しない
+- 差分の実装着手前の承認(「差分レポートの提示」)は省略しない。auto mode 等の既定動作より `.claude/rules/implementation-rules.md` を優先する

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "yarn": "pnpmを使用してください"
   },
   "scripts": {
-    "build": "run-s build:pathpida build:next",
+    "build": "run-s build:panda build:pathpida build:next",
     "build-storybook": "storybook build",
     "build:next": "next build",
+    "build:panda": "panda codegen",
     "build:pathpida": "pathpida --ignorePath .gitignore",
     "check-code": "npm-run-all -p lint spell-check type-check -s test-jest",
     "dev": "run-p dev:*",
@@ -29,7 +30,7 @@
     "prepare": "run-s \"prepare:*\"",
     "prepare-bk:playwright": "pnpm exec playwright install",
     "prepare:huksy": "husky",
-    "prepare:panda": "panda codegen",
+    "prepare:panda": "pnpm build:panda",
     "prepare:pathpida": "pnpm build:pathpida",
     "preview": "run-s build start",
     "spell-check": "cspell lint --no-progress \"./**/*.{js,mjs,ts,tsx}\" \"./*.{js,mjs}\"",

--- a/src/components/atoms/EslintConfigJsIntroduction/constants/LINK_ITEMS/index.ts
+++ b/src/components/atoms/EslintConfigJsIntroduction/constants/LINK_ITEMS/index.ts
@@ -4,12 +4,8 @@ export const LINK_ITEMS = [
     label: "ESLint",
   },
   {
-    href: "https://eslint.style/",
-    label: "ESLint Stylistic",
-  },
-  {
-    href: "https://www.npmjs.com/package/eslint-config-airbnb",
-    label: "eslint-config-airbnb",
+    href: "https://www.npmjs.com/package/eslint-plugin-import",
+    label: "eslint-plugin-import",
   },
   {
     href: "https://www.npmjs.com/package/eslint-plugin-unicorn",

--- a/src/components/atoms/EslintConfigJsIntroduction/index.tsx
+++ b/src/components/atoms/EslintConfigJsIntroduction/index.tsx
@@ -1,6 +1,5 @@
 import { Fragment } from "react"
 
-import { Link } from "../Link"
 import { UnOrderLinkList } from "../UnOrderLinkList"
 import { LINK_ITEMS } from "./constants/LINK_ITEMS"
 
@@ -12,13 +11,5 @@ export const EslintConfigJsIntroduction: FC = () => (
       This package sets some rules based on the shared config of below packages.
     </p>
     <UnOrderLinkList items={LINK_ITEMS} />
-    <p>
-      And, set some rules from
-      {" "}
-      <Link href="https://www.npmjs.com/package/eslint-plugin-import">
-        eslint-plugin-import
-      </Link>
-      .
-    </p>
   </Fragment>
 )

--- a/src/components/atoms/EslintConfigNextIntroduction/constants/LINK_ITEMS/index.ts
+++ b/src/components/atoms/EslintConfigNextIntroduction/constants/LINK_ITEMS/index.ts
@@ -2,8 +2,8 @@ import { pagesPath } from "@lib/$path"
 
 export const LINK_ITEMS = [
   {
-    href: "https://www.npmjs.com/package/eslint-config-next",
-    label: "eslint-config-next",
+    href: "https://www.npmjs.com/package/@next/eslint-plugin-next",
+    label: "@next/eslint-plugin-next",
   },
   {
     href: pagesPath.packages.eslint_config_sc_react.$url().path,

--- a/src/components/atoms/EslintConfigReactIntroduction/constants/LINK_ITEMS/index.ts
+++ b/src/components/atoms/EslintConfigReactIntroduction/constants/LINK_ITEMS/index.ts
@@ -2,15 +2,15 @@ import { pagesPath } from "@lib/$path"
 
 export const LINK_ITEMS = [
   {
-    href: "https://www.npmjs.com/package/eslint-plugin-react",
-    label: "eslint-plugin-react",
-  },
-  {
-    href: "https://www.npmjs.com/package/eslint-plugin-react-hook",
-    label: "eslint-plugin-react-hook",
-  },
-  {
     href: pagesPath.packages.eslint_config_sc_js.$url().path,
     label: "eslint-config-sc-js",
+  },
+  {
+    href: "https://www.npmjs.com/package/eslint-plugin-jsx-a11y",
+    label: "eslint-plugin-jsx-a11y",
+  },
+  {
+    href: "https://www.npmjs.com/package/eslint-plugin-react",
+    label: "eslint-plugin-react",
   },
 ] as const satisfies Array<Record<"href" | "label", string>>

--- a/src/components/atoms/EslintConfigTsIntroduction/constants/LINK_ITEMS/index.ts
+++ b/src/components/atoms/EslintConfigTsIntroduction/constants/LINK_ITEMS/index.ts
@@ -2,11 +2,15 @@ import { pagesPath } from "@lib/$path"
 
 export const LINK_ITEMS = [
   {
-    href: "https://typescript-eslint.io/",
-    label: "typescript-eslint",
-  },
-  {
     href: pagesPath.packages.eslint_config_sc_js.$url().path,
     label: "eslint-config-sc-js",
+  },
+  {
+    href: "https://www.npmjs.com/package/eslint-import-resolver-typescript",
+    label: "eslint-import-resolver-typescript",
+  },
+  {
+    href: "https://typescript-eslint.io/",
+    label: "typescript-eslint",
   },
 ] as const satisfies Array<Record<"href" | "label", string>>

--- a/src/components/templates/EslintConfigSCAll/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCAll/components/atoms/Installation/index.tsx
@@ -3,6 +3,7 @@ import { Fragment } from "react"
 import { HEADINGS_INFO } from "@shared/constants/HEADINGS_INFO"
 
 import { Heading3 } from "../../../../../atoms/Heading3"
+import { Note } from "../../../../../atoms/Note"
 import { PackageManagerTabContents } from "../../../../../organisms/PackageManagerTabContents"
 
 import type { FC } from "react"
@@ -26,5 +27,12 @@ export const Installation: FC = () => (
       pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
       yarn={`$ yarn add -D ${PACKAGE_NAME}`}
     />
+
+    <Note>
+      Also install eslint-config-sc-js or eslint-config-sc-ts depending on the first
+      (javascript / typescript) argument of getConfigs(), and eslint-config-sc-jest /
+      eslint-config-sc-next / eslint-config-sc-react / eslint-config-sc-storybook depending
+      on which library names you pass as the second argument.
+    </Note>
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCJest/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCJest/components/atoms/Installation/index.tsx
@@ -15,16 +15,17 @@ const {
   },
 } = HEADINGS_INFO
 const PACKAGE_NAME = "eslint-config-sc-jest"
+const PEER_DEPENDENCIES = "eslint-plugin-jest"
 
 export const Installation: FC = () => (
   <Fragment>
     <Heading3 id={INSTALLATION.hash}>{INSTALLATION.name}</Heading3>
 
     <PackageManagerTabContents
-      bun={`$ bun add -D ${PACKAGE_NAME}`}
-      npm={`$ npm i -D ${PACKAGE_NAME}`}
-      pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
-      yarn={`$ yarn add -D ${PACKAGE_NAME}`}
+      bun={`$ bun add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      npm={`$ npm i -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      pnpm={`$ pnpm add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      yarn={`$ yarn add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
     />
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCJs/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCJs/components/atoms/Installation/index.tsx
@@ -15,16 +15,17 @@ const {
   },
 } = HEADINGS_INFO
 const PACKAGE_NAME = "eslint-config-sc-js"
+const PEER_DEPENDENCIES = "@eslint/eslintrc @eslint/js eslint-plugin-import eslint-plugin-unicorn"
 
 export const Installation: FC = () => (
   <Fragment>
     <Heading3 id={INSTALLATION.hash}>{INSTALLATION.name}</Heading3>
 
     <PackageManagerTabContents
-      bun={`$ bun add -D ${PACKAGE_NAME}`}
-      npm={`$ npm i -D ${PACKAGE_NAME}`}
-      pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
-      yarn={`$ yarn add -D ${PACKAGE_NAME}`}
+      bun={`$ bun add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      npm={`$ npm i -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      pnpm={`$ pnpm add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      yarn={`$ yarn add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
     />
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCJs/components/atoms/Setup/constants/CODES/index.ts
+++ b/src/components/templates/EslintConfigSCJs/components/atoms/Setup/constants/CODES/index.ts
@@ -10,7 +10,7 @@ import eslintConfigSCJs from "eslint-config-sc-js"
 
 export default [
   eslintConfigSCJs.configs.initialRecord,
-  eslintConfigSCJs.configs.stylisticRecord,
+  eslintConfigSCJs.configs.importRecommendedRecord,
   eslintConfigSCJs.configs.eslintRecommendedRecord,
   eslintConfigSCJs.configs.unicornRecommendedRecords,
 
@@ -20,8 +20,5 @@ export default [
 
   // This is the custom config of eslint-config-sc-js
   eslintConfigSCJs.configs.customRecord,
-
-  // This is the reset config for @stylistic
-  eslintConfigSCJs.configs.resetRecordForStylistic,
 ].flat()`,
 }

--- a/src/components/templates/EslintConfigSCNext/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCNext/components/atoms/Installation/index.tsx
@@ -15,16 +15,17 @@ const {
   },
 } = HEADINGS_INFO
 const PACKAGE_NAME = "eslint-config-sc-next"
+const PEER_DEPENDENCIES = "@next/eslint-plugin-next eslint-config-sc-react"
 
 export const Installation: FC = () => (
   <Fragment>
     <Heading3 id={INSTALLATION.hash}>{INSTALLATION.name}</Heading3>
 
     <PackageManagerTabContents
-      bun={`$ bun add -D ${PACKAGE_NAME}`}
-      npm={`$ npm i -D ${PACKAGE_NAME}`}
-      pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
-      yarn={`$ yarn add -D ${PACKAGE_NAME}`}
+      bun={`$ bun add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      npm={`$ npm i -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      pnpm={`$ pnpm add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      yarn={`$ yarn add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
     />
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCNext/components/atoms/Setup/constants/CODES/index.ts
+++ b/src/components/templates/EslintConfigSCNext/components/atoms/Setup/constants/CODES/index.ts
@@ -10,19 +10,15 @@ import eslintConfigSCNext from "eslint-config-sc-next"
 
 export default [
   eslintConfigSCNext.configs.initialRecord,
-  eslintConfigSCNext.configs.stylisticRecord,
   eslintConfigSCNext.configs.eslintRecommendedRecord,
   eslintConfigSCNext.configs.unicornRecommendedRecords,
   eslintConfigSCNext.configs.reactRecords,
-  eslintConfigSCNext.configs.nextRecords,
+  eslintConfigSCNext.configs.nextRecord,
   eslintConfigSCNext.configs.airbnbRecords,
 
   // This is the custom config of eslint-config-sc-js / eslint-config-sc-next
   eslintConfigSCNext.configs.scJsCustomRecord,
   eslintConfigSCNext.configs.scRectCustomRecord,
-
-  // This is the reset config for stylistic
-  eslintConfigSCNext.configs.resetRecordForStylistic,
 ].flat()`,
   FLAT3: `// eslint.config.mjs
 import eslintConfigSCTs from "eslint-config-sc-ts"
@@ -30,21 +26,16 @@ import eslintConfigSCNext from "eslint-config-sc-next"
 
 export default [
   eslintConfigSCNext.configs.initialRecord,
-  eslintConfigSCNext.configs.stylisticRecord,
   eslintConfigSCNext.configs.eslintRecommendedRecord,
   eslintConfigSCTs.configs.typescriptEslintStrictTypeCheckedRecords,
-  eslintConfigSCTs.configs.typescriptEslintStylisticTypeCheckedRecords,
   eslintConfigSCNext.configs.unicornRecommendedRecords,
   eslintConfigSCNext.configs.reactRecords,
-  eslintConfigSCNext.configs.nextRecords,
+  eslintConfigSCNext.configs.nextRecord,
   eslintConfigSCNext.configs.airbnbRecords,
 
   eslintConfigSCNext.configs.scJsCustomRecord,
-  eslintConfigSCTs.configs.customRecords,
-  eslintConfigSCNext.configs.customRecord,
-  eslintConfigSCNext.configs.customRecordWithTypescript,
-
-  // This is the reset config for stylistic
-  eslintConfigSCNext.configs.resetRecordForStylistic,
+  eslintConfigSCTs.configs.customRecord,
+  eslintConfigSCNext.configs.scRectCustomRecord,
+  eslintConfigSCNext.configs.scRectCustomRecordWithTypescript,
 ].flat()`,
 }

--- a/src/components/templates/EslintConfigSCReact/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCReact/components/atoms/Installation/index.tsx
@@ -15,16 +15,17 @@ const {
   },
 } = HEADINGS_INFO
 const PACKAGE_NAME = "eslint-config-sc-react"
+const PEER_DEPENDENCIES = "eslint-config-sc-js eslint-config-sc-ts eslint-plugin-jsx-a11y"
 
 export const Installation: FC = () => (
   <Fragment>
     <Heading3 id={INSTALLATION.hash}>{INSTALLATION.name}</Heading3>
 
     <PackageManagerTabContents
-      bun={`$ bun add -D ${PACKAGE_NAME}`}
-      npm={`$ npm i -D ${PACKAGE_NAME}`}
-      pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
-      yarn={`$ yarn add -D ${PACKAGE_NAME}`}
+      bun={`$ bun add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      npm={`$ npm i -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      pnpm={`$ pnpm add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      yarn={`$ yarn add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
     />
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCReact/components/atoms/Setup/constants/CODES/index.ts
+++ b/src/components/templates/EslintConfigSCReact/components/atoms/Setup/constants/CODES/index.ts
@@ -10,7 +10,6 @@ import eslintConfigSCReact from "eslint-config-sc-react"
 
 export default [
   eslintConfigSCReact.configs.initialRecord,
-  eslintConfigSCReact.configs.stylisticRecord,
   eslintConfigSCReact.configs.eslintRecommendedRecord,
   eslintConfigSCReact.configs.unicornRecommendedRecords,
   eslintConfigSCReact.configs.reactRecords,
@@ -19,9 +18,6 @@ export default [
   // This is the custom config of eslint-config-sc-js / eslint-config-sc-react
   eslintConfigSCReact.configs.scJsCustomRecord,
   eslintConfigSCReact.configs.customRecord,
-
-  // This is the reset config for stylistic
-  eslintConfigSCReact.configs.resetRecordForStylistic,
 ].flat()`,
   FLAT3: `// eslint.config.mjs
 import eslintConfigSCTs from "eslint-config-sc-ts"
@@ -29,11 +25,9 @@ import eslintConfigSCReact from "eslint-config-sc-react"
 
 export default [
   eslintConfigSCReact.configs.initialRecord,
-  eslintConfigSCReact.configs.stylisticRecord,
   eslintConfigSCReact.configs.eslintRecommendedRecord,
   eslintConfigSCReact.configs.unicornRecommendedRecords,
   eslintConfigSCTs.configs.typescriptEslintStrictTypeCheckedRecords,
-  eslintConfigSCTs.configs.typescriptEslintStylisticTypeCheckedRecords,
   eslintConfigSCReact.configs.reactRecords,
   eslintConfigSCReact.configs.airbnbRecords,
 
@@ -41,8 +35,5 @@ export default [
   eslintConfigSCReact.configs.scJsCustomRecord,
   eslintConfigSCReact.configs.customRecord,
   eslintConfigSCReact.configs.customRecordWithTypescript,
-
-  // This is the reset config for stylistic
-  eslintConfigSCReact.configs.resetRecordForStylistic,
 ].flat()`,
 }

--- a/src/components/templates/EslintConfigSCStorybook/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCStorybook/components/atoms/Installation/index.tsx
@@ -15,16 +15,17 @@ const {
   },
 } = HEADINGS_INFO
 const PACKAGE_NAME = "eslint-config-sc-storybook"
+const PEER_DEPENDENCIES = "eslint-plugin-storybook"
 
 export const Installation: FC = () => (
   <Fragment>
     <Heading3 id={INSTALLATION.hash}>{INSTALLATION.name}</Heading3>
 
     <PackageManagerTabContents
-      bun={`$ bun add -D ${PACKAGE_NAME}`}
-      npm={`$ npm i -D ${PACKAGE_NAME}`}
-      pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
-      yarn={`$ yarn add -D ${PACKAGE_NAME}`}
+      bun={`$ bun add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      npm={`$ npm i -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      pnpm={`$ pnpm add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      yarn={`$ yarn add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
     />
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCTs/components/atoms/Installation/index.tsx
+++ b/src/components/templates/EslintConfigSCTs/components/atoms/Installation/index.tsx
@@ -15,16 +15,17 @@ const {
   },
 } = HEADINGS_INFO
 const PACKAGE_NAME = "eslint-config-sc-ts"
+const PEER_DEPENDENCIES = "@eslint/eslintrc @eslint/js eslint-config-sc-js eslint-import-resolver-typescript typescript-eslint"
 
 export const Installation: FC = () => (
   <Fragment>
     <Heading3 id={INSTALLATION.hash}>{INSTALLATION.name}</Heading3>
 
     <PackageManagerTabContents
-      bun={`$ bun add -D ${PACKAGE_NAME}`}
-      npm={`$ npm i -D ${PACKAGE_NAME}`}
-      pnpm={`$ pnpm add -D ${PACKAGE_NAME}`}
-      yarn={`$ yarn add -D ${PACKAGE_NAME}`}
+      bun={`$ bun add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      npm={`$ npm i -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      pnpm={`$ pnpm add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
+      yarn={`$ yarn add -D ${PACKAGE_NAME} ${PEER_DEPENDENCIES}`}
     />
   </Fragment>
 )

--- a/src/components/templates/EslintConfigSCTs/components/atoms/Setup/constants/CODES/index.ts
+++ b/src/components/templates/EslintConfigSCTs/components/atoms/Setup/constants/CODES/index.ts
@@ -17,11 +17,10 @@ import eslintConfigSCTs from "eslint-config-sc-ts"
 
 export default [
   eslintConfigSCTs.configs.initialRecord,
-  eslintConfigSCTs.configs.stylisticRecord,
+  eslintConfigSCTs.configs.importRecommendedRecord,
   eslintConfigSCTs.configs.eslintRecommendedRecord,
   eslintConfigSCTs.configs.unicornRecommendedRecords,
   eslintConfigSCTs.configs.typescriptEslintStrictTypeCheckedRecords,
-  eslintConfigSCTs.configs.typescriptEslintStylisticTypeCheckedRecords,
 
   // This use eslint-config-airbnb-base
   // For react project, this replace to eslint-config-airbnb
@@ -30,9 +29,6 @@ export default [
   // This is the custom config of eslint-config-sc-js / eslint-config-sc-ts
   eslintConfigSCTs.configs.scJsCustomRecord,
   eslintConfigSCTs.configs.customRecord,
-
-  // This is the reset config for stylistic
-  eslintConfigSCTs.configs.resetRecordForStylistic,
   {
     languageOptions: {
       parserOptions: {

--- a/src/components/templates/EslintPluginSCJs/components/atoms/Setup/index.tsx
+++ b/src/components/templates/EslintPluginSCJs/components/atoms/Setup/index.tsx
@@ -21,7 +21,7 @@ import eslintPluginSCJs from "eslint-plugin-sc-js"
 export default [
   {
     plugins: {
-      "js": eslintPluginSCJs, // It is not necessary when use the recommended config
+      "sc-js": eslintPluginSCJs, // It is not necessary when use the recommended config
     },
   },
   eslintPluginSCJs.configs.recommended,

--- a/src/components/templates/EslintPluginSCJsRules/components/atoms/Setup/index.tsx
+++ b/src/components/templates/EslintPluginSCJsRules/components/atoms/Setup/index.tsx
@@ -11,7 +11,7 @@ import eslintPluginSCJs from "eslint-plugin-sc-js"
 export default [
   {
     plugins: {
-      "js": eslintPluginSCJs, // It is not necessary when use the recommended config
+      "sc-js": eslintPluginSCJs, // It is not necessary when use the recommended config
     },
   },
   eslintPluginSCJs.configs.recommended,


### PR DESCRIPTION
## 概要

本家 [strict-check](https://github.com/akky-xxxx/strict-check) のリリース内容をこのドキュメントサイトへ同期するためのスキル `sync-strict-check` を追加し、そのスキルに沿って各パッケージのドキュメントを本家の実装に同期した。

## 変更内容

### スキルの追加

- `.claude/skills/sync-strict-check/SKILL.md` を追加
  - 同期マトリクスに「plugin の登録キーとルール名の prefix」の観点を含め、実キーが `SUFFIX` + `PLUGIN_NAME` の連結であることを明記
  - `CODES` が参照する `configs` キーを機械的に全件抽出し、実在キーと総当たりで突き合わせる手順を記載

### ドキュメントの同期

- **Introduction**: shared config の由来リンクを各 record の実装に合わせて修正(参照されなくなったパッケージを削除、欠落分を追加、`eslint-config-next` → `@next/eslint-plugin-next`)
- **Installation**: 各パッケージの peerDependencies をインストールコマンドに追記。`eslint-config-sc-all` は `getConfigs()` の引数によって必要なパッケージが変わるため、固定コマンドではなく Note で案内
- **Setup**: コードサンプルから実在しない `configs` キー(`stylisticRecord` / `resetRecordForStylistic` / `typescriptEslintStylisticTypeCheckedRecords`)を削除し、欠落していた `importRecommendedRecord` を追加、誤記(`nextRecords` 等)を修正
- **eslint-plugin-sc-js**: 手動登録サンプルの `plugins` キーを `js` → `sc-js` に修正。誤ったままだと各ルールページが案内する `sc-js/<rule>` が解決できず "Definition for rule not found" になる

## 確認

- `pnpm check-code` グリーン(lint / spell-check / type-check 通過、jest 13 suites 55 tests 全パス)

🤖 Generated with [Claude Code](https://claude.com/claude-code)